### PR TITLE
Add titleframeopts

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -797,16 +797,19 @@ def expand_autotemplate_gen_opening(autotemplate):
         the string the with generated latex code
     """
     titleframe = False
+    titleframeopts = ''
     out = []
     for item in autotemplate:
-        if item[0]!='titleframe':
-            out.append('\\%s%s' % item)
-        else:
+        if item[0] == 'titleframe':
             titleframe = parse_bool(item[1])
+        elif item[0] == 'titleframeopts':
+            titleframeopts = item[1]
+        else:
+            out.append('\\%s%s' % item)
 
     out.append('\n\\begin{document}\n')
     if titleframe:
-        out.append('\n\\frame{\\titlepage}\n')
+        out.append('\n\\frame%s{\\titlepage}\n' % titleframeopts)
 
     return '\n'.join(out)
 

--- a/doc/man/wiki2beamer.xml
+++ b/doc/man/wiki2beamer.xml
@@ -197,7 +197,10 @@ lstdefinestyle={basic}{....}
 titleframe=True
 [autotemplate]&gt;</programlisting>
 				titleframe is a special key that tells wiki2beamer to create a title frame. To set the title, subtitle and author of the presentation
-				use the keys title, subtitle and author. Overriding of the default options works on</para>
+				use the keys title, subtitle and author.
+				Another special key related to the titleframe key is the titleframeopts key: If set, the value will be passed to
+				the titleframe as options. A commonly useful setting is titleframeopts=[plain].
+				Overriding of the default options works on</para>
 				<itemizedlist>
 					<listitem>per-key level for: documentclass, titleframe</listitem>
 					<listitem>per-package level for: usepackage</listitem>


### PR DESCRIPTION
When enabling the titleframe in autotemplate, this new option permits to specify options for the titleframe. For example, I like to use titleframe=[plain]