### PR TITLE
Fix regex / pprint for python 3.7

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -73,8 +73,6 @@ def pprint(string, file=sys.stdout, eol=True):
     else:
         file.write(string.encode('utf-8'))
     
-    
-    
     if eol:
         file.write(os.linesep)
     file.flush()

--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -68,7 +68,13 @@ def pprint(string, file=sys.stdout, eol=True):
     if file == sys.stderr and _redirected_stderr is not None:
         file = _redirected_stderr
 
-    file.write(string.encode('utf-8'))
+    if file == sys.stderr or file == sys.stdout:
+        file.write(string)
+    else:
+        file.write(string.encode('utf-8'))
+    
+    
+    
     if eol:
         file.write(os.linesep)
     file.flush()
@@ -424,13 +430,13 @@ def transform_vspacestar(string):
 def transform_uncover(string):
     """uncover"""
     p = re.compile("\+<(.*)>\s*{(.*)") # +<1-2>{.... -> \uncover<1-2>{....
-    string = p.sub(r"\uncover<\1>{\2", string)
+    string = p.sub(r"\\uncover<\1>{\2", string)
     return string
 
 def transform_only(string):
     """only"""
     p = re.compile("-<(.*)>\s*{(.*)") # -<1-2>{.... -> \only<1-2>{....
-    string = p.sub(r"\only<\1>{\2", string)
+    string = p.sub(r"\\only<\1>{\2", string)
     return string
 
 def transform(string, state):


### PR DESCRIPTION
Hi,
it seems that your repository is the "reference" one for wiki2beamer (I hope I am right :-) )

I am using it almost on a daily basis, and I experienced some troubles with python 3.7.
* In `transform_uncover` and `transform_only` where the regex patterns needed a fix
* In `pprint` because of encoding issues when redirecting to `stderr` or `stdout`

I hope I chose the right way for the fix, especially for `pprint`

Best regards,
T.